### PR TITLE
Basic App Build + Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+dist/

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const resolve = dir => path.join(__dirname, '..', dir);
+
+module.exports = {
+  entry: {
+    app: resolve('src/main.js')
+  },
+  output: {
+    path: resolve('dist'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader'
+      },
+      {
+        test: /\.js$/,
+        loader: 'buble-loader',
+        exclude: /node_modules/
+      }]
+  },
+  resolve: {
+    extensions: ['.js', '.vue', '.json']
+  },
+  devtool: '#cheap-module-source-map'
+};
+
+// This handles minifying and compressing code for a production build simply set the NODE_ENV environment variable to production
+if (process.env.NODE_ENV === 'production') {
+  module.exports.devtool = '#source-map';
+  // http://vue-loader.vuejs.org/en/workflow/production.html
+  module.exports.plugins = (module.exports.plugins || []).concat([
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
+      compress: {
+        warnings: false
+      }
+    }),
+    new webpack.LoaderOptionsPlugin({
+      minimize: true
+    })
+  ]);
+}

--- a/layout.html
+++ b/layout.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>My App</title>
+</head>
+
+<body>
+  <div>
+    <div id="app">
+      <!--vue-ssr-outlet-->
+    </div>
+  </div>
+  <script src="/dist/app.js"></script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -7,13 +7,24 @@
     "body-parser": "^1.18.2",
     "console.table": "^0.9.1",
     "express": "^4.16.2",
+    "express-layout": "^0.1.0",
     "mysql": "^2.15.0",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "vue": "^2.5.10"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "buble-loader": "^0.4.1",
+    "cross-env": "^5.1.1",
+    "vue-loader": "^13.5.0",
+    "webpack": "^3.10.0",
+    "vue-template-compiler": "^2.5.10"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "npm run build:dev && node server.js",
+    "build:dev": "cross-env NODE_ENV=development webpack --config=config/webpack.config.js --progress --hide-modules",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "express": "^4.16.2",
     "express-layout": "^0.1.0",
     "mysql": "^2.15.0",
-    "path": "^0.12.7",
     "vue": "^2.5.10"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,9 +1,13 @@
 var express = require("express");
 var bodyParser = require("body-parser");
+const layout = require('express-layout');
 
 var port = process.env.PORT || 8080;
 
 var app = express();
+
+app.use(layout());
+app.set('layout', './layout');
 
 // Serve static content for the app from the "public" directory in the application directory.
 app.use(express.static("public"));

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="container-fluid">
+    <h1>I am a vue app!</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'app'
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,13 @@
+import App from './App';
+import Vue from 'vue';
+
+import about from './pages/about';
+
+/* eslint-disable no-new */
+new Vue({
+  components: {
+    App
+  },
+  el: '#app',
+  template: '<App/>'
+});

--- a/src/pages/about/index.vue
+++ b/src/pages/about/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1>About Page!</h1>
+</template>
+
+<script>
+export default {
+  name: 'about'
+}
+</script>


### PR DESCRIPTION
- Adds webpack setup + build tools
- Adds `src` folder for vue build
- Adds `layout.html` to house vue templates
- Adds a Main.js and App.vue in order to give a boilerplate
- Adds `src/pages/about/index.vue` as a boilerplate can be removed
- Adds `express-layout` to use the actual layout.html
- Adds new npm scripts `npm run build`, and `npm run build:dev`
- Updates the start script to run `build:dev` by default before starting

Do note I am unsure if the express-layout is going to work as expected I am hoping it will but I couldn't run app tests since I don't have a db to hook into. 

This is essentially everything on the front end that Vue-Cli will give you. And since we never actually covered build tools for react or anything this should help take care of that

It includes a production build as well just run the `npm run build` which is considered a very strict production ready build. (You can't really debug it since it's VERY difficult at that state)